### PR TITLE
Extend communication protocol, remove CLAMP parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.py[cod]
 *$py.class
 .ipynb_checkpoints/
+env/

--- a/config.yml
+++ b/config.yml
@@ -11,11 +11,6 @@ NUM_TILES_WIDTH: 10
 # The number of RGB LEDS on each strip.
 NUM_LEDS_PER_STRIP: 140
 
-# 255, or 0xFF is being used a sentinel value in message strings sent to the
-# controllers. CLAMP then, represents the highest value that should be sent as
-# part of a color message.
-CLAMP: 254
-
 # Safe amount of time (milis) between consecutive writes to the same unit.
 RATE_LIMIT_TIME: 100
 
@@ -29,7 +24,7 @@ UNITS:
   a:
     north_south: 9
     west_east: 6
-    serial_port: '/dev/ttyACM2'
+    serial_port: '/dev/ttyACM0'
   b:
     north_south: 5
     west_east: 6
@@ -37,4 +32,4 @@ UNITS:
   c:
     north_south: 5
     west_east: 2
-    serial_port: '/dev/ttyACM0'
+    serial_port: '/dev/ttyACM2'

--- a/twilight-arduino/TeensyID.cpp
+++ b/twilight-arduino/TeensyID.cpp
@@ -1,0 +1,156 @@
+/* TeensyMAC library code is placed under the MIT license
+ * Copyright (c) 2017 Stefan Staub
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "TeensyID.h"
+#include <Arduino.h>
+
+#define MY_SYSREGISTERFILE	((uint8_t *)0x40041000) // System Register File
+
+static uint32_t getTeensySerial(void) {
+	uint32_t num;
+	__disable_irq();
+	#if defined(HAS_KINETIS_FLASH_FTFA) || defined(HAS_KINETIS_FLASH_FTFL)
+		FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
+		FTFL_FCCOB0 = 0x41;
+		FTFL_FCCOB1 = 15;
+		FTFL_FSTAT = FTFL_FSTAT_CCIF;
+		while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
+		num = *(uint32_t *)&FTFL_FCCOB7;
+	#elif defined(HAS_KINETIS_FLASH_FTFE)
+		kinetis_hsrun_disable();
+		FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
+		*(uint32_t *)&FTFL_FCCOB3 = 0x41070000;
+		FTFL_FSTAT = FTFL_FSTAT_CCIF;
+		while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
+		num = *(uint32_t *)&FTFL_FCCOBB;
+		kinetis_hsrun_enable();
+	#endif
+	__enable_irq();
+	return num;
+	}
+
+	uint32_t teensyUsbSN() {
+		uint32_t num = getTeensySerial();
+		if (num < 10000000) num = num * 10;
+		return num;
+		}
+
+	void teensySN(uint8_t *sn) {
+		uint32_t num = getTeensySerial();
+		sn[0] = num >> 24;
+		sn[1] = num >> 16;
+		sn[2] = num >> 8;
+		sn[3] = num;
+		}
+
+	const char* teensySN(void) {
+		uint8_t serial[4];
+		static char teensySerial[12];
+		teensySN(serial);
+		sprintf(teensySerial, "%02x-%02x-%02x-%02x", serial[0], serial[1], serial[2], serial[3]);
+		return teensySerial;
+		}
+
+	void teensyMAC(uint8_t *mac) {
+		uint8_t serial[4];
+		teensySN(serial);
+		mac[0] = 0x04;
+		mac[1] = 0xE9;
+		mac[2] = 0xE5;
+		mac[3] = serial[1];
+		mac[4] = serial[2];
+		mac[5] = serial[3];
+		}
+
+	const char* teensyMAC(void) {
+		uint8_t mac[6];
+		static char teensyMac[18];
+		teensyMAC(mac);
+		sprintf(teensyMac, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+		return teensyMac;
+		}
+
+#if defined (__MKL26Z64__) // 80bit UID Teensy LC
+
+	void kinetisUID(uint32_t *uid) {
+		uid[0] = SIM_UIDMH;
+		uid[1] = SIM_UIDML;
+		uid[2] = SIM_UIDL;
+		}
+
+	const char* kinetisUID(void) {
+		uint32_t uid[3];
+		static char uidString[27];
+		kinetisUID(uid);
+		sprintf(uidString, "%08x-%08x-%08x", uid[0], uid[1], uid[2]);
+		return uidString;
+	}
+
+#elif defined (__MK20DX128__) || defined (__MK20DX256__) || defined (__MK64FX512__) || defined (__MK66FX1M0__) // 128bit UID Teensy 3.0, 3.1, 3.2, 3.5, 3.6
+
+	void kinetisUID(uint32_t *uid) {
+  	uid[0] = SIM_UIDH;
+  	uid[1] = SIM_UIDMH;
+  	uid[2] = SIM_UIDML;
+  	uid[3] = SIM_UIDL;
+		}
+
+	const char* kinetisUID(void) {
+		uint32_t uid[4];
+		static char uidString[36];
+		kinetisUID(uid);
+  	sprintf(uidString, "%08x-%08x-%08x-%08x", uid[0], uid[1], uid[2], uid[3]);
+		return uidString;
+	}
+
+#endif
+
+void teensyUUID(uint8_t *uuid) {
+	uint8_t mac[6];
+	teensyMAC(mac);
+	uuid[0] = SIM_UIDML >> 24;
+	uuid[1] = SIM_UIDML >> 16;
+	uuid[2] = SIM_UIDML >> 8;
+	uuid[3] = SIM_UIDML;
+	uuid[4] = SIM_UIDL >> 24;
+	uuid[5] = SIM_UIDL >> 16;
+	uuid[6] = 0x40; // marked as version v4, but this uuid is not random based !!!
+	uuid[7] = SIM_UIDL >> 8;
+	uuid[8] = 0x80; //variant
+	uuid[9] = SIM_UIDL;
+	uuid[10] = mac[0];
+	uuid[11] = mac[1];
+	uuid[12] = mac[2];
+	uuid[13] = mac[3];
+	uuid[14] = mac[4];
+	uuid[15] = mac[5];
+	}
+
+const char* teensyUUID(void) {
+	uint8_t uuid[16];
+	static char uuidString[37];
+	teensyUUID(uuid);
+	sprintf(uuidString, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x", uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+	return uuidString;
+	}

--- a/twilight-arduino/TeensyID.h
+++ b/twilight-arduino/TeensyID.h
@@ -1,0 +1,131 @@
+/* TeensyMAC library code is placed under the MIT license
+ * Copyright (c) 2017 Stefan Staub
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/** Teensy Library for different IDs of Teensy LC and Teensy 3.0 ... 3.6
+  *
+  * - USB Serial Number
+  * - Teensy Serial Number
+  * - MAC Address
+  * - Kinetis Chip UID
+  * - UUID (RFC4122) pseudo v4
+  *
+  * @code
+  *  #include <TeensyID.h>
+  *
+  * uint8_t serial[4];
+  * uint8_t mac[6];
+  * uint32_t uid[4];
+  * uint8_t uuid[16];
+  *
+  * void setup() {
+  *   teensySN(serial);
+  *   teensyMAC(mac);
+  *   kinetisUID(uid);
+  *   teensyUUID(uuid);
+  *   delay(2000);
+  *   Serial.printf("USB Serialnumber: %u \n", teensyUsbSN());
+  *   Serial.printf("Array Serialnumber: %02X-%02X-%02X-%02X \n", serial[0], serial[1], serial[2], serial[3]);
+  *   Serial.printf("String Serialnumber: %s\n", teensySN());
+  *   Serial.printf("Array MAC Address: %02X:%02X:%02X:%02X:%02X:%02X \n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  *   Serial.printf("String MAC Address: %s\n", teensyMAC());
+  *   Serial.printf("Array 128-bit UniqueID from chip: %08X-%08X-%08X-%08X\n", uid[0], uid[1], uid[2], uid[3]);
+  *   Serial.printf("String 128-bit UniqueID from chip: %s\n", kinetisUID());
+  *   Serial.printf("Array 128-bit UUID RFC4122: %02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X\n", uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+  *   Serial.printf("String 128-bit UUID RFC4122: %s\n", teensyUUID());
+  *   }
+  *
+  * void loop() {}
+  *
+  * @endcode
+  */
+
+#ifndef TEENSYID_H
+#define TEENSYID_H
+
+#include <stdint.h>
+
+/** Teens USB Serial Number
+  *
+  * @ returns
+  * The USB Serial Number
+  */
+uint32_t teensyUsbSN();
+
+/** Teensy Serial Number
+  *
+  * @param sn Pointer to an  array with size of 4 uint8_t which contents the serial number
+  */
+void teensySN(uint8_t *sn);
+
+/** Teensy Serial Number
+  *
+  * @returns
+  * A formated string in hex xx-xx-xx-xx
+  */
+const char* teensySN(void);
+
+/** Teensy MAC Address
+  *
+  * @param mac Pointer to an array with size of 6 uint8_t which contents the mac address
+  */
+void teensyMAC(uint8_t *mac);
+
+/** Teensy MAC Address
+  *
+  * @returns
+  * A formated string in hex xx:xx:xx:xx:xx:xx
+  */
+const char* teensyMAC(void);
+
+/** Kinetis Chip UID
+  *
+  * @param uid Pointer to an array with size of 4 uint32_t which contents the kinetis uid
+  */
+void kinetisUID(uint32_t *uid);
+
+/** Kinetis Chip UID
+  *
+  * @returns
+  * A formated string in hex xxxx:xxxx:xxxx:xxxx
+  */
+const char* kinetisUID(void);
+
+/** Teensy UUID (RFC4122)
+  *
+  * @param mac Pointer to an array with size of 16 uint8_t which contents the uuid
+  *
+  * @note
+  * It is an UUID extracted from the Kinetis UID and the MAC Address.
+  * It is marked as version 4, (pseudo)random based
+  */
+void teensyUUID(uint8_t *uid);
+
+/** Teensy UUID (RFC4122)
+  *
+  * @returns
+  * A formated string in hex xxxx-xx-xx-xx-xxxxxx
+  */
+const char* teensyUUID(void);
+
+#endif

--- a/twilight-arduino/twilight-arduino.ino
+++ b/twilight-arduino/twilight-arduino.ino
@@ -1,27 +1,93 @@
+#include <EEPROM.h>
 #include <FastLED.h>
+
+#ifndef __AVR__
+#include "TeensyID.h"
+#endif
 
 #define NUM_LEDS 140
 #define DATA_PIN 6
 
+const uint8_t handshake[] = {0xDE, 0xAD, 0xBE, 0xEF};
+
 CRGB leds[NUM_LEDS];
-int num_bytes = 0;
+
+typedef void (*Function) (void);
+
+void send_hardware_serial();
+void display_frame();
+void write_eeprom();
+
+uint8_t blocking_serial_read() {
+    while(Serial.available() == 0);
+    return Serial.read();
+}
+
+const Function func_table[] = {
+    // 0x00
+    send_hardware_serial,
+
+    // 0x01
+    display_frame,
+
+    // 0x02
+    write_eeprom
+};
+
+void send_hardware_serial() {
+    uint8_t serial_id[4];
+    #ifdef __AVR__
+    serial_id[0] = EEPROM.read(0);
+    serial_id[1] = EEPROM.read(1);
+    serial_id[2] = EEPROM.read(2);
+    serial_id[3] = EEPROM.read(3);
+    #else
+    teensySN(serial_id);
+    #endif
+
+    Serial.write(serial_id, sizeof(serial_id));
+}
+
+void display_frame() {
+    int bytes_read = 0;
+    while(bytes_read < NUM_LEDS * 3) {
+        bytes_read += Serial.readBytes(((uint8_t*) leds) + bytes_read, NUM_LEDS * 3 - bytes_read);
+    }
+    FastLED.show();
+}
+
+void write_eeprom() {
+    uint8_t address = blocking_serial_read();
+    uint8_t value = blocking_serial_read();
+
+    EEPROM.write(address, value);
+}
 
 void setup() {
-  // put your setup code here, to run once:
-  Serial.begin(460800);
+    // Note: on Teensy the set baud rate has no effect
+    // Communication is always performed at 12Mbps
+    Serial.begin(460800);
 
-  FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
-  fill_rainbow(leds, NUM_LEDS, 222);
-  //fill_solid(leds, NUM_LEDS, CRGB(255, 0, 0));
+    FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
+    fill_rainbow(leds, NUM_LEDS, 222);
+    FastLED.show();
 }
 
 void loop() {
-  FastLED.show();
+    bool valid_header = 1;    
+    while(blocking_serial_read() != handshake[0]);
+    for(int i = 1; i < sizeof(handshake); i++) {
+        if(blocking_serial_read() != handshake[i]) {
+            valid_header = 0;
+            break;
+        }
+    }
 
-  while(Serial.read() != 0xFF);
+    if(valid_header) {
+        uint8_t command = blocking_serial_read();
 
-  int bytesRead = 0;
-  while(bytesRead < NUM_LEDS * 3) {
-    bytesRead += Serial.readBytes(((uint8_t*)leds) + bytesRead, NUM_LEDS * 3 - bytesRead);
-  }
+        if(command < 3) {
+            func_table[command]();
+        }
+    }
 }

--- a/twilight.py
+++ b/twilight.py
@@ -9,6 +9,12 @@ from config_loader import config_loader
 """The name of the YAML file from which to get configuration."""
 CONFIG_FILE_NAME = 'config.yml'
 
+"""Synchronization header to send to the Teensy on each command."""
+SYNC_HEADER = b'\xDE\xAD\xBE\xEF'
+
+"""Command byte that tells the Teensy to display a frame."""
+CMD_DISPLAY_FRAME = SYNC_HEADER + b'\x01'
+
 
 default_config = {
     # The number of full tiles in the North-South span of the room.
@@ -19,11 +25,6 @@ default_config = {
 
     # The number of RGB LEDS on each strip.
     'NUM_LEDS_PER_STRIP': 140,
-
-    # 255, or 0xFF is being used as a sentinel value in message strings sent to the
-    # controllers. CLAMP then, represents the highest value that should be sent as
-    # part of a color message.
-    'CLAMP': 254,
 
     # Safe amount of time (milis) between consecutive writes to the same unit.
     'RATE_LIMIT_TIME': 10,
@@ -90,7 +91,7 @@ class Twilight:
                     daemon=True,
                     args=(unit_queue, port)
                 )
-                unit_queue.put(b'\xFF' + b'\x00x00x00' * config['NUM_LEDS_PER_STRIP'])
+                unit_queue.put(CMD_DISPLAY_FRAME + b'\x00x00x00' * config['NUM_LEDS_PER_STRIP'])
                 self.threads[unit].start()
 
     def update_lights_helper(self, unit_queue, port):
@@ -158,10 +159,9 @@ class Twilight:
         # Colors are input as RGB. However, our LEDs take RBG :/
         rbg_colors = [(col[0], col[2], col[1]) for col in colors]
 
-        # Build the message and make sure all values are between 0 and CLAMP
+        # Build the message
         serialized_colors = list(sum(rbg_colors, ()))
-        serialized_colors = [max(0, min(config['CLAMP'], c)) for c in serialized_colors]
-        message = b'\xFF' + bytes(serialized_colors)
+        message = CMD_DISPLAY_FRAME + bytes(serialized_colors)
 
         if config['DEBUG_MODE']:
             # TODO: pass values to visualizer


### PR DESCRIPTION
Communication protocol between computer and microcontroller now supports three different commands:

1. Request hardware ID (on Arduino this just reads the first 4 bytes of the EEPROM, on Teensy this will fetch the MAC). Takes no additional bytes, returns 4 bytes.

2. Display frame. Takes 3 * NUM_LEDS bytes, returns no bytes.

3. Write byte to EEPROM. Takes 2 bytes (address, value), returns no bytes.

The handshake used to synchronize the computer and microcontroller has also been changed. Instead of sending 0xFF, 0xDEADBEEF should be sent instead. This also means that CLAMP is no longer necessary as 0xFF is not a sentinel value by itself.