### PR TITLE
Implement dynamic plugin loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,12 @@
+from plugin_manager import PluginManager
+
+
+def main():
+    manager = PluginManager()
+    manager.loadPlugin("mood")
+    manager.loadPlugin("epilepsy")
+    manager.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/config.yml
+++ b/config.yml
@@ -33,3 +33,9 @@ UNITS:
     north_south: 5
     west_east: 2
     serial_port: '/dev/ttyACM2'
+
+# Folder for holding plugins
+PLUGINS_FOLDER: '/plugins/'
+
+# Default program length, in seconds
+PLUGIN_CYCLE_LENGTH: 30

--- a/config_loader.py
+++ b/config_loader.py
@@ -13,17 +13,27 @@ class Config:
         self.config_dicts = {}
 
     def register_config(self, config_name, filename, my_dict):
+        """Notifies the config loader of a config file that should be loaded.
+        All registered config files are automatically reloaded when load_config
+        is called."""
+
         if config_name not in self.config_files:
             self.config_files[config_name] = filename
             self.config_dicts[config_name] = my_dict
 
     def load_config(self, my_config_key=None):
+        """Reload all registered config files. If my_config_key is specified, returns
+        the dictionary corresponding to the given key."""
+
         for config_key in self.config_files:
             filename = self.config_files[config_key]
             my_dict = self.config_dicts[config_key]
+
             """Read file and set values"""
             with open(filename, 'r') as f:
                 config_dict = ruamel.yaml.load(f.read(), ruamel.yaml.RoundTripLoader)
+
+                """Dictionaries must have a key for every variable in a config file."""
                 for key in config_dict:
                     if key not in my_dict:
                         raise RuntimeError("%s has not been declared in %s plugin" % (key, config_key))

--- a/plugin_base.py
+++ b/plugin_base.py
@@ -4,10 +4,15 @@ class Plugin:
         self.tile_matrix = []
 
     def ready(self):
+        """Specifies whether this plugin is ready to return a frame."""
         return False
 
     def setTileMatrix(self, tile_matrix):
+        """Update the tile matrix used by this plugin."""
         self.tile_matrix = tile_matrix
 
     def getNextFrame(self):
+        """Returns one frame of color data in a dictionary where unit IDs
+        map to either a tuple or a list of tuples. Single tuples imply that
+        all LEDs in the panel should be set to that color."""
         raise NotImplementedError('getNextFrame not implemented.')

--- a/plugin_base.py
+++ b/plugin_base.py
@@ -1,0 +1,13 @@
+class Plugin:
+
+    def __init__(self):
+        self.tile_matrix = []
+
+    def ready(self):
+        return False
+
+    def setTileMatrix(self, tile_matrix):
+        self.tile_matrix = tile_matrix
+
+    def getNextFrame(self):
+        raise NotImplementedError('getNextFrame not implemented.')

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -1,0 +1,99 @@
+import imp
+import os
+import time
+import twilight
+from config_loader import config_loader
+
+
+class PluginManager:
+
+    """Service for switching between plugins for Twilight"""
+    def __init__(self):
+        PLUGIN_FILE_NAME = 'plugins.yml'
+
+        default_config = {
+            # Plugin data, priority in range 0-9 inclusive, persistent is boolean
+            'PLUGINS': {}
+        }
+
+        config_loader.register_config('plugin', PLUGIN_FILE_NAME, default_config)
+        self.plugins = config_loader.load_config('plugin')
+        self.loaded_plugins = []
+        self.blocked = {}
+        self.config = config_loader.load_config('twilight')
+
+    def getAvailablePlugins(self):
+        """List all plugins located in the folder given in the config PLUGINS_FOLDER"""
+        available_plugins = {}
+        location = "." + self.config["PLUGINS_FOLDER"]
+        for plugin_folder in os.listdir(location):
+            plugin_files = os.listdir(location+plugin_folder)
+            if "__init__.py" in plugin_files:
+                try:
+                    available_plugins[plugin_folder] = {
+                        "name": plugin_folder,
+                        "path": location+plugin_folder+"/__init__.py",
+                        "priority": self.plugins["PLUGINS"][plugin_folder]['priority'],
+                        "persistent": self.plugins["PLUGINS"][plugin_folder]['persistent']
+                    }
+                except KeyError:
+                    # config.json not correctly formatted
+                    pass
+            else:
+                # incorrectly formatted plugin
+                pass
+        return available_plugins
+
+    def loadPlugin(self, plugin_name):
+        """Loads plugin named plugin_name from plugins folder"""
+        plugins = self.getAvailablePlugins()
+        if plugin_name in plugins and plugin_name not in self.blocked:
+            plugin_obj = {
+                "name": plugin_name,
+                "path": plugins[plugin_name]["path"],
+                "priority": plugins[plugin_name]["priority"],
+                "persistent": plugins[plugin_name]["persistent"]
+            }
+            self.blocked[plugin_name] = True
+            for index in range(len(self.loaded_plugins)):
+                if self.loaded_plugins[index]["priority"] < plugin_obj["priority"]:
+                    self.loaded_plugins.insert(index, plugin_obj)
+                    return
+            self.loaded_plugins.append(plugin_obj)
+        else:
+            # plugin not found
+            pass
+
+    def getNextPlugin(self):
+        for plugin in self.loaded_plugins:
+            module = imp.load_source("__init__", plugin["path"])
+            if module.ready():
+                if not plugin["persistent"]:
+                    self.loaded_plugins.remove(plugin)
+                    del self.blocked[plugin["name"]]  # allow this plugin to be re-added
+                return module
+        return None
+
+    def start(self):
+        """Begins cycling through plugins"""
+        current_module = None  # TODO: replace with default module
+        current_plugin = None
+        while True:
+            current_time = time.time()
+            next_module = self.getNextPlugin()
+            if next_module and not next_module == current_module:
+                current_module = next_module
+                current_plugin = current_module.Plugin()
+                current_plugin.setTileMatrix(twilight.interface.tile_matrix)
+            while time.time() < current_time + self.config["PLUGIN_CYCLE_LENGTH"]:
+                tile_matrix = current_plugin.getNextFrame()
+                for pixel in tile_matrix:
+                    twilight.interface.set_unit_color(pixel, tile_matrix[pixel])
+                time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    manager = PluginManager()
+    manager.loadPlugin("mood")
+    manager.loadPlugin("epilepsy")
+    manager.start()

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,0 +1,11 @@
+# This is the central documentation for plugin settings.
+# Plugins not listed here are non-persistent and have priority 0
+
+# Plugin data, priority in range 0-9 inclusive, persistent is boolean
+PLUGINS:
+  epilepsy:
+    priority: 0
+    persistent: False
+  mood:
+    priority: 0
+    persistent: False

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,5 +1,7 @@
 # This is the central documentation for plugin settings.
 # Plugins not listed here are non-persistent and have priority 0
+# Priority determines order in which plugins will be played. Higher values will be played first
+# Persistence determines whether or not a plugin will be removed from the queue upon termination
 
 # Plugin data, priority in range 0-9 inclusive, persistent is boolean
 PLUGINS:

--- a/plugins/epilepsy/__init__.py
+++ b/plugins/epilepsy/__init__.py
@@ -1,16 +1,14 @@
 import random
+from plugin_base import Plugin
 
 
-class Plugin:
+class EpilepsyPlugin(Plugin):
 
     def __init__(self):
-        self.tile_matrix = []
+        Plugin.__init__(self)
 
     def ready(self):
         return True
-
-    def setTileMatrix(self, tile_matrix):
-        self.tile_matrix = tile_matrix
 
     def getNextFrame(self):
         """Returns a dict of the form unit_id:(r,g,b)"""

--- a/plugins/epilepsy/__init__.py
+++ b/plugins/epilepsy/__init__.py
@@ -1,4 +1,5 @@
 import random
+import time
 from plugin_base import Plugin
 
 
@@ -6,9 +7,10 @@ class EpilepsyPlugin(Plugin):
 
     def __init__(self):
         Plugin.__init__(self)
+        self.last_frame_time = 0
 
     def ready(self):
-        return True
+        return time.time() - self.last_frame_time > 0.1
 
     def getNextFrame(self):
         """Returns a dict of the form unit_id:(r,g,b)"""
@@ -19,7 +21,8 @@ class EpilepsyPlugin(Plugin):
         for row in self.tile_matrix:
             for tile in row:
                 if tile is not None:
-                    frame[tile["unit"]] = (red, green, blue)
+                    frame[tile["unit"]] = [(red, green, blue)] * 140
+        self.last_frame_time = time.time()
         return frame
 
 

--- a/plugins/epilepsy/__init__.py
+++ b/plugins/epilepsy/__init__.py
@@ -1,0 +1,24 @@
+import random
+
+
+class Plugin:
+
+    def __init__(self):
+        self.tile_matrix = []
+
+    def ready(self):
+        return True
+
+    def setTileMatrix(self, tile_matrix):
+        self.tile_matrix = tile_matrix
+
+    def getNextFrame(self):
+        """Returns a dict of the form unit_id:(r,g,b)"""
+        red = random.randint(0, 254)
+        green = random.randint(0, 254)
+        blue = random.randint(0, 254)
+        frame = {}
+        for tile in self.tile_matrix:
+            if tile is not None:
+                frame[tile["unit"]] = (red, green, blue)
+        return frame

--- a/plugins/epilepsy/__init__.py
+++ b/plugins/epilepsy/__init__.py
@@ -16,7 +16,11 @@ class EpilepsyPlugin(Plugin):
         green = random.randint(0, 254)
         blue = random.randint(0, 254)
         frame = {}
-        for tile in self.tile_matrix:
-            if tile is not None:
-                frame[tile["unit"]] = (red, green, blue)
+        for row in self.tile_matrix:
+            for tile in row:
+                if tile is not None:
+                    frame[tile["unit"]] = (red, green, blue)
         return frame
+
+
+plugin = EpilepsyPlugin

--- a/plugins/mood/__init__.py
+++ b/plugins/mood/__init__.py
@@ -1,17 +1,15 @@
 import colorsys
+from plugin_base import Plugin
 
 
-class Plugin:
+class MoodLightPlugin(Plugin):
 
     def __init__(self):
+        Plugin.__init__(self)
         self.hue = 0.0
-        self.tile_matrix = []
 
     def ready(self):
         return True
-
-    def setTileMatrix(self, tile_matrix):
-        self.tile_matrix = tile_matrix
 
     def getNextFrame(self):
         self.hue += 0.0025

--- a/plugins/mood/__init__.py
+++ b/plugins/mood/__init__.py
@@ -1,0 +1,26 @@
+import colorsys
+
+
+class Plugin:
+
+    def __init__(self):
+        self.hue = 0.0
+        self.tile_matrix = []
+
+    def ready(self):
+        return True
+
+    def setTileMatrix(self, tile_matrix):
+        self.tile_matrix = tile_matrix
+
+    def getNextFrame(self):
+        self.hue += 0.0025
+        red, green, blue = colorsys.hsv_to_rgb(self.hue, 1.0, 1.0)
+        red = int(255 * red)
+        green = int(255 * green)
+        blue = int(255 * blue)
+        frame = {}
+        for tile in self.tile_matrix:
+            if tile is not None:
+                frame[tile["unit"]] = (red, green, blue)
+        return frame

--- a/plugins/mood/__init__.py
+++ b/plugins/mood/__init__.py
@@ -18,7 +18,11 @@ class MoodLightPlugin(Plugin):
         green = int(255 * green)
         blue = int(255 * blue)
         frame = {}
-        for tile in self.tile_matrix:
-            if tile is not None:
-                frame[tile["unit"]] = (red, green, blue)
+        for row in self.tile_matrix:
+            for tile in row:
+                if tile is not None:
+                    frame[tile["unit"]] = (red, green, blue)
         return frame
+
+
+plugin = MoodLightPlugin

--- a/plugins/mood/__init__.py
+++ b/plugins/mood/__init__.py
@@ -1,4 +1,5 @@
 import colorsys
+import time
 from plugin_base import Plugin
 
 
@@ -7,9 +8,10 @@ class MoodLightPlugin(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.hue = 0.0
+        self.last_frame_time = 0
 
     def ready(self):
-        return True
+        return time.time() - self.last_frame_time > 0.1
 
     def getNextFrame(self):
         self.hue += 0.0025
@@ -22,6 +24,7 @@ class MoodLightPlugin(Plugin):
             for tile in row:
                 if tile is not None:
                     frame[tile["unit"]] = (red, green, blue)
+        self.last_frame_time = time.time()
         return frame
 
 

--- a/twilight.py
+++ b/twilight.py
@@ -36,7 +36,13 @@ default_config = {
     'DEBUG_MODE': True,
 
     # Information about Twilight panel units.
-    'UNITS': {}
+    'UNITS': {},
+
+    # Folder for holding plugins
+    'PLUGINS_FOLDER': '/plugins/',
+
+    # Default program length, in seconds
+    'PLUGIN_CYCLE_LENGTH': 30
 }
 
 


### PR DESCRIPTION
Plugins can now be loaded at runtime. Currently plugins will be cycled through on a fixed rotation; the logic for this can be changed if necessary.

Define the plugin directory in `config.yml`, plugin order, priority and persistence in `plugins.yml`, and plugins can provide their own config files if they need them (which should be loaded using ConfigLoader).